### PR TITLE
fix undo for textarea

### DIFF
--- a/index.js
+++ b/index.js
@@ -172,5 +172,16 @@ function insertText(el, text, start, end) {
     text = '';
   }
   var value = el.value.replace(/\r\n/g, '\n');
-  el.value = [value.slice(0, start), text, value.slice(end)].join('');
+  // fix problems with undo/redo.
+  // Thanks to [StackOverflow](http://stackoverflow.com/questions/7553430/javascript-textarea-undo-redo)
+  var event = document.createEvent('TextEvent');
+  if ('function' === typeof event.initTextEvent) {
+    event.initTextEvent('textInput', true, true, null, text);
+    el.selectionStart = start;
+    el.selectionEnd = end;
+    el.dispatchEvent(event);
+  } else {
+    // fallback for firefox or old opera. And, probably, old IEs
+    el.value = [value.slice(0, start), text, value.slice(end)].join('');
+  }
 }

--- a/selection.js
+++ b/selection.js
@@ -173,7 +173,18 @@ function insertText(el, text, start, end) {
     text = '';
   }
   var value = el.value.replace(/\r\n/g, '\n');
-  el.value = [value.slice(0, start), text, value.slice(end)].join('');
+  // fix problems with undo/redo.
+  // Thanks to [StackOverflow](http://stackoverflow.com/questions/7553430/javascript-textarea-undo-redo)
+  var event = document.createEvent('TextEvent');
+  if ('function' === typeof event.initTextEvent) {
+    event.initTextEvent('textInput', true, true, null, text);
+    el.selectionStart = start;
+    el.selectionEnd = end;
+    el.dispatchEvent(event);
+  } else {
+    // fallback for firefox or old opera. And, probably, old IEs
+    el.value = [value.slice(0, start), text, value.slice(end)].join('');
+  }
 }
 
 root.Selection = Selection;


### PR DESCRIPTION
I'm using `TextEvent` event to add updates into undo-stack. It's work for me in Firefox, Chrome and Safari. 